### PR TITLE
Add a "qualified" version for commands Parametricity & Parametricity Recursive.

### DIFF
--- a/src/abstraction.ml4
+++ b/src/abstraction.ml4
@@ -88,6 +88,14 @@ VERNAC COMMAND EXTEND AbstractionRecursive CLASSIFIED AS SIDEFF
   [
     command_reference_recursive arity (Constrintern.intern_reference c)
   ]
+| [ "Parametricity" "Recursive" reference(c) "qualified" ] ->
+  [
+    command_reference_recursive ~fullname:true default_arity (Constrintern.intern_reference c)
+  ]
+| [ "Parametricity" "Recursive" reference(c) "arity" integer(arity) "qualified" ] ->
+  [
+    command_reference_recursive ~fullname:true arity (Constrintern.intern_reference c)
+  ]
 END
 
 VERNAC COMMAND EXTEND Abstraction CLASSIFIED AS SIDEFF

--- a/src/abstraction.ml4
+++ b/src/abstraction.ml4
@@ -57,6 +57,10 @@ VERNAC COMMAND EXTEND AbstractionReference CLASSIFIED AS SIDEFF
   [
     command_reference default_arity (Constrintern.intern_reference c) (Some name)
   ]
+| [ "Parametricity" reference(c) "qualified" ] -> 
+  [
+    command_reference ~fullname:true default_arity (Constrintern.intern_reference c) None
+  ]
 | [ "Parametricity" reference(c) "arity" int(arity) ] -> 
   [
     command_reference arity (Constrintern.intern_reference c) None  
@@ -64,6 +68,10 @@ VERNAC COMMAND EXTEND AbstractionReference CLASSIFIED AS SIDEFF
 | [ "Parametricity" reference(c) "arity" int(arity) "as" ident(name) ] ->
   [
     command_reference arity (Constrintern.intern_reference c) (Some name)  
+  ]
+| [ "Parametricity" reference(c) "arity" int(arity) "qualified" ] ->
+  [
+    command_reference ~fullname:true arity (Constrintern.intern_reference c) None
   ]
 | [ "Parametricity" reference(c)  "as" ident(name) "arity" integer(arity) ] -> 
   [

--- a/src/declare_translation.ml
+++ b/src/declare_translation.ml
@@ -386,7 +386,7 @@ let command_reference ?(continuation = default_continuation) ?(fullname = false)
    | ConstructRef constructor ->
      command_constructor ~continuation arity gref names
 
-let command_reference_recursive ?(continuation = default_continuation) arity gref =
+let command_reference_recursive ?(continuation = default_continuation) ?(fullname = false) arity gref =
   let open Globnames in
   let gref= Globnames.canonical_gr gref in
   let label = Names.Label.of_id (Nametab.basename_of_global gref) in
@@ -416,7 +416,7 @@ let command_reference_recursive ?(continuation = default_continuation) arity gre
   (* DEBUG: *)
   let open Pp in msg_info  (str "DepRefs:");
   List.iter (fun x -> let open Pp in msg_info (Printer.pr_global x)) dep_refs;
-  list_continuation continuation (fun continuation gref -> command_reference ~continuation arity gref None) dep_refs ()
+  list_continuation continuation (fun continuation gref -> command_reference ~continuation ~fullname arity gref None) dep_refs ()
 
 let translate_command arity c name =
   if !ongoing_translation then error (Pp.str "On going translation.");


### PR DESCRIPTION
Hi @aa755 
With @proux01 we are trying to compile [CoqEAL](https://github.com/CoqEAL/CoqEAL) (that depends on paramcoq) with Coq 8.7
Your paramcoq fork does compile with Coq 8.7, but this new code https://github.com/aa755/paramcoq/blob/14234dd1ed1679df0cc0f3bc511c6a67e79fad44/src/declare_translation.ml#L312-L324 in branch `v8.7` makes a non-backward-compatible change. This is an issue because it would prevent for example to keep CoqEAL compatible with both Coq 8.6 and 8.7.
IIUC, this extra qualification `Module_o_Submodule_o_constant` helps reducing some name clash if `constant` already exists in current scope.
However, this was already possible to avoid any name clash by doing for example:
```
Parametricity negb.
Fail Parametricity negb.
Module Foo.
Parametricity negb. (* OK *)
End Foo.
```
Anyway, the current version of this PR is a trade-off between two versions:
- By default, the Parametricity vernacular does not "qualify" anymore the generated constant so this restore backward-compatibility.
- The new behavior `Module_o_Submodule_o_constant` is bound to a new vernacular `Parametricity negb qualified.`

If you think that it is really important to keep this `Module_o_Submodule_o_constant` feature, you may merge this PR... otherwise this feature could just be removed.
Cc @CohenCyril